### PR TITLE
fix: implement security fixes and oracle integration (H1, C2, M3, M2,…

### DIFF
--- a/script/deploy/local/V1/ContractsLinker.s.sol
+++ b/script/deploy/local/V1/ContractsLinker.s.sol
@@ -78,6 +78,9 @@ contract ContractsLinker is Script {
         } else {
             _ensureAddress(fundingManager.feeVaultManager(), address(feeVaultManager));
         }
+        if (address(fundingManager.priceOracleAdapter()) != address(mockOracleAdapter)) {
+            fundingManager.setPriceOracleAdapter(address(mockOracleAdapter));
+        }
 
         // OrderBookManager
         if (orderBookManager.eventManager() == address(0)) {

--- a/src/core/FundingManager.sol
+++ b/src/core/FundingManager.sol
@@ -8,8 +8,12 @@ import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+import {FixedPointMathLib} from "@solady/utils/FixedPointMathLib.sol";
 
 import "../interfaces/core/IFundingManager.sol";
+import "../interfaces/oracle/IPriceOracle.sol";
 
 /**
  * @title FundingManager
@@ -25,6 +29,7 @@ contract FundingManager is
     IFundingManager
 {
     using SafeERC20 for IERC20;
+    using Address for address payable;
 
     // ============ 常量 Constants ============
 
@@ -71,6 +76,11 @@ contract FundingManager is
     /// @notice FeeVaultManager 合约地址(用于调用权限控制)
     address public feeVaultManager;
 
+    /// @notice Price oracle adapter for token-to-USD price lookups
+    /// @dev Typed as IPriceOracle for type-safe interface calls.
+    ///      When set to address(0), falls back to hardcoded 1:1 USD assumption.
+    IPriceOracle public priceOracleAdapter;
+
     /// @notice Token 配置
     struct TokenConfig {
         uint8 decimals;
@@ -82,6 +92,9 @@ contract FundingManager is
 
     /// @notice 支持的 Token 列表
     address[] public supportedTokens;
+
+    /// @notice Token existence tracking for O(1) duplicate check
+    mapping(address => bool) private _tokenExists;
 
     // ============ 余额管理 Balance Management ============
 
@@ -142,7 +155,7 @@ contract FundingManager is
     mapping(address => uint256) public totalWithdrawn;
 
     // ===== Upgradeable storage gap =====
-    uint256[50] private _gap;
+    uint256[49] private _gap;
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
@@ -206,6 +219,10 @@ contract FundingManager is
         if (!config.isEnabled) revert TokenIsNotSupported(tokenAddress);
         if (amount == 0) revert LessThanZero(amount);
 
+        if (tokenAddress == NATIVE_TOKEN) {
+            require(ethValue == amount, "FundingManager: ETH amount mismatch");
+        }
+
         uint256 usdAmount = _normalizeToUsd(tokenAddress, amount);
         require(usdAmount >= minDepositPerTxnUsd, "FundingManager: deposit below minimum");
 
@@ -218,9 +235,7 @@ contract FundingManager is
         require(remainingUsd >= minTokenBalanceUsd, "FundingManager: token balance below minimum");
 
         // Handle token transfer
-        if (tokenAddress == NATIVE_TOKEN) {
-            require(ethValue == amount, "FundingManager: ETH amount mismatch");
-        } else {
+        if (tokenAddress != NATIVE_TOKEN) {
             IERC20(tokenAddress).safeTransferFrom(user, address(this), amount);
         }
 
@@ -284,8 +299,7 @@ contract FundingManager is
 
         // 转账
         if (tokenAddress == NATIVE_TOKEN) {
-            (bool sent, ) = withdrawAddress.call{value: tokenAmount}("");
-            require(sent, "FundingManager: failed to send ETH");
+            withdrawAddress.sendValue(tokenAmount);
         } else {
             IERC20(tokenAddress).safeTransfer(withdrawAddress, tokenAmount);
         }
@@ -307,18 +321,9 @@ contract FundingManager is
         config.decimals = decimals;
         config.isEnabled = enabled;
 
-        if (enabled) {
-            // 检查是否已存在,避免重复添加
-            bool exists = false;
-            for (uint256 i = 0; i < supportedTokens.length; i++) {
-                if (supportedTokens[i] == token) {
-                    exists = true;
-                    break;
-                }
-            }
-            if (!exists) {
-                supportedTokens.push(token);
-            }
+        if (enabled && !_tokenExists[token]) {
+            supportedTokens.push(token);
+            _tokenExists[token] = true;
         }
 
         emit TokenConfigured(token, decimals, enabled, block.chainid);
@@ -330,7 +335,10 @@ contract FundingManager is
         if (config.decimals > 18) revert InvalidTokenDecimals(config.decimals);
 
         uint256 factor = 10 ** (18 - config.decimals);
-        return rawAmount * factor;
+        uint256 normalized = rawAmount * factor;
+
+        uint256 price = getTokenPrice(token);
+        return FixedPointMathLib.mulDiv(normalized, price, USD_PRECISION);
     }
 
     function _denormalizeFromUsd(address token, uint256 usdAmount) internal view returns (uint256) {
@@ -338,8 +346,11 @@ contract FundingManager is
         if (!config.isEnabled) revert TokenIsNotSupported(token);
         if (config.decimals > 18) revert InvalidTokenDecimals(config.decimals);
 
+        uint256 price = getTokenPrice(token);
+        uint256 normalized = FixedPointMathLib.mulDiv(usdAmount, USD_PRECISION, price);
+
         uint256 factor = 10 ** (18 - config.decimals);
-        return usdAmount / factor;
+        return normalized / factor;
     }
 
     /**
@@ -362,11 +373,16 @@ contract FundingManager is
 
     /**
      * @notice 获取 Token 价格 (USD, 1e18)
-     * @dev TODO: 接入 OracleAdapter 实时价格
+     * @dev Queries the price oracle adapter if configured, otherwise falls back to 1:1.
      */
-    function getTokenPrice(address token) external view returns (uint256) {
+    function getTokenPrice(address token) public view returns (uint256) {
         TokenConfig memory config = tokenConfigs[token];
         if (!config.isEnabled) revert TokenIsNotSupported(token);
+
+        if (address(priceOracleAdapter) != address(0)) {
+            return priceOracleAdapter.getTokenPrice(token);
+        }
+
         return 1e18;
     }
 
@@ -470,8 +486,7 @@ contract FundingManager is
         tokenLiquidity[token] -= amount;
 
         if (token == NATIVE_TOKEN) {
-            (bool sent, ) = payable(recipient).call{value: amount}("");
-            require(sent, "FundingManager: failed to send ETH");
+            payable(recipient).sendValue(amount);
         } else {
             IERC20(token).safeTransfer(recipient, amount);
         }
@@ -665,7 +680,10 @@ contract FundingManager is
         uint8 outcomeIndex
     ) external onlyOrderBookManager nonReentrant {
         // 计算买家支付金额
-        uint256 payment = (matchAmount * matchPrice) / PRICE_PRECISION;
+        uint256 payment = FixedPointMathLib.mulDiv(matchAmount, matchPrice, PRICE_PRECISION);
+
+        // Prevent zero-payment trades that would give buyer free Long Tokens
+        require(payment > 0 || matchAmount == 0, "FundingManager: payment rounds to zero");
 
         // 买家: 消耗锁定的 USD,获得 Long Token
         require(orderLockedUsd[buyOrderId] >= payment, "FundingManager: insufficient locked USD");
@@ -691,8 +709,12 @@ contract FundingManager is
      * @param eventId 事件 ID
      * @param winningOutcomeIndex 获胜结果索引
      */
-    function markEventSettled(uint256 eventId, uint8 winningOutcomeIndex) external onlyEventManager nonReentrant {
+    function markEventSettled(uint256 eventId, uint8 winningOutcomeIndex) external onlyOrderBookManager nonReentrant {
         require(!eventSettled[eventId], "FundingManager: event already settled");
+
+        uint8[] storage outcomes = eventOutcomes[eventId];
+        require(outcomes.length > 0, "FundingManager: event not registered");
+        require(winningOutcomeIndex < outcomes.length, "FundingManager: invalid winning outcome");
 
         eventSettled[eventId] = true;
         eventWinningOutcome[eventId] = winningOutcomeIndex;
@@ -856,6 +878,16 @@ contract FundingManager is
         feeVaultManager = _feeVaultManager;
     }
 
+    /**
+     * @notice Set the price oracle adapter address
+     * @param _priceOracleAdapter The price oracle adapter address
+     */
+    function setPriceOracleAdapter(address _priceOracleAdapter) external onlyOwner nonReentrant {
+        require(_priceOracleAdapter != address(0), "FundingManager: invalid address");
+        priceOracleAdapter = IPriceOracle(_priceOracleAdapter);
+        emit PriceOracleAdapterUpdated(_priceOracleAdapter);
+    }
+
     // ============ 紧急控制 Emergency Control ============
 
     /**
@@ -863,5 +895,9 @@ contract FundingManager is
      */
     // ============ 接收 ETH ============
 
-    receive() external payable {}
+    /// @notice Reject direct ETH transfers to prevent accidental fund loss
+    receive() external payable {
+        // TODO: Route to deposit ETH when ETH support is fully enabled
+        revert("FundingManager: direct ETH transfers not supported");
+    }
 }

--- a/src/interfaces/core/IFundingManager.sol
+++ b/src/interfaces/core/IFundingManager.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IPriceOracle} from "../oracle/IPriceOracle.sol";
 
 /**
  * @title IFundingManager
@@ -54,6 +55,9 @@ interface IFundingManager {
 
     /// @notice Token 可用最低余额更新事件
     event MinTokenBalanceUsdUpdated(uint256 newMinBalance);
+
+    /// @notice Price oracle adapter updated event
+    event PriceOracleAdapterUpdated(address indexed newAdapter);
 
     // ============ 错误 Errors ============
 
@@ -389,6 +393,11 @@ interface IFundingManager {
     function feeVaultManager() external view returns (address);
 
     /**
+     * @notice Get the price oracle adapter
+     */
+    function priceOracleAdapter() external view returns (IPriceOracle);
+
+    /**
      * @notice 更新 OrderBookManager 地址
      * @param _orderBookManager 新地址
      */
@@ -405,4 +414,10 @@ interface IFundingManager {
      * @param _feeVaultManager 新地址
      */
     function setFeeVaultManager(address _feeVaultManager) external;
+
+    /**
+     * @notice Set the price oracle adapter address
+     * @param _priceOracleAdapter The price oracle adapter address
+     */
+    function setPriceOracleAdapter(address _priceOracleAdapter) external;
 }

--- a/src/interfaces/oracle/IMockOracleAdapter.sol
+++ b/src/interfaces/oracle/IMockOracleAdapter.sol
@@ -2,12 +2,13 @@
 pragma solidity ^0.8.20;
 
 import {IOracle} from "./IOracle.sol";
+import {IPriceOracle} from "./IPriceOracle.sol";
 
 /**
  * @title IMockOracleAdapter
  * @notice MockOracleAdapter 接口
  */
-interface IMockOracleAdapter is IOracle {
+interface IMockOracleAdapter is IOracle, IPriceOracle {
     /**
      * @notice 初始化合约
      * @param initialOwner 初始所有者地址

--- a/src/interfaces/oracle/IPriceOracle.sol
+++ b/src/interfaces/oracle/IPriceOracle.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title IPriceOracle
+/// @notice Adapter interface for synchronous token price feeds used by FundingManager
+/// @dev This is the adapter interface (owned by us), not an external oracle interface.
+///      FundingManager imports this interface and calls it via typed reference.
+///      Adapters implement this interface and internally handle oracle-specific logic.
+interface IPriceOracle {
+    /// @notice Get the USD price of a token
+    /// @param token The token address
+    /// @return price The price in USD (1e18 precision, e.g., 1e18 = $1.00)
+    function getTokenPrice(address token) external view returns (uint256 price);
+}

--- a/src/oracle/mock/MockOracleAdapter.sol
+++ b/src/oracle/mock/MockOracleAdapter.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import "../../interfaces/oracle/IOracle.sol";
+import "../../interfaces/oracle/IPriceOracle.sol";
 
 interface IMockOracle {
     function requestResult(uint256 eventId, uint8 numOutcomes) external returns (uint256 requestId);
@@ -16,7 +17,7 @@ interface IMockOracle {
  * @title MockOracleAdapter
  * @notice Adapter that wraps MockOracle and translates callbacks to EventManager.
  */
-contract MockOracleAdapter is Initializable, OwnableUpgradeable, UUPSUpgradeable, IOracle {
+contract MockOracleAdapter is Initializable, OwnableUpgradeable, UUPSUpgradeable, IOracle, IPriceOracle {
     struct OracleRequest {
         bytes32 requestId;
         uint256 eventId;
@@ -163,6 +164,16 @@ contract MockOracleAdapter is Initializable, OwnableUpgradeable, UUPSUpgradeable
 
         require(oracleConsumer != address(0), "MockOracleAdapter: oracleConsumer not set");
         IOracleConsumer(oracleConsumer).fulfillResult(eventId, winningOutcomeIndex, proof);
+    }
+
+    // ============ IPriceOracle Implementation ============
+
+    /// @notice Returns hardcoded 1:1 USD price for all tokens (stablecoin assumption)
+    /// @param token The token address (unused in mock)
+    /// @return price Always returns 1e18 ($1.00)
+    function getTokenPrice(address token) external pure override returns (uint256 price) {
+        token;
+        return 1e18;
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}

--- a/test/unit/CoreContractsSecurityFixes.t.sol
+++ b/test/unit/CoreContractsSecurityFixes.t.sol
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {EventManager} from "../../src/core/EventManager.sol";
+import {FeeVaultManager} from "../../src/core/FeeVaultManager.sol";
+import {FundingManager} from "../../src/core/FundingManager.sol";
+import {OrderBookManager} from "../../src/core/OrderBookManager.sol";
+import {EventManagerProxy} from "../../src/core/proxies/EventManagerProxy.sol";
+import {FeeVaultManagerProxy} from "../../src/core/proxies/FeeVaultManagerProxy.sol";
+import {FundingManagerProxy} from "../../src/core/proxies/FundingManagerProxy.sol";
+import {OrderBookManagerProxy} from "../../src/core/proxies/OrderBookManagerProxy.sol";
+import {MockOracleAdapter} from "../../src/oracle/mock/MockOracleAdapter.sol";
+
+contract FundingManagerHarness is FundingManager {
+    function exposedDeposit(address user, address tokenAddress, uint256 amount, uint256 ethValue) external {
+        _deposit(user, tokenAddress, amount, ethValue);
+    }
+}
+
+contract CoreContractsSecurityFixesTest is Test {
+    address internal owner;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+    }
+
+    function _deployFundingManagerWithManagers()
+        internal
+        returns (FundingManager fm, address orderBook, address eventMgr)
+    {
+        FundingManager fmImpl = new FundingManager();
+        bytes memory fmInitData = abi.encodeWithSignature("initialize(address)", owner);
+        FundingManagerProxy fmProxy = new FundingManagerProxy(address(fmImpl), fmInitData);
+        fm = FundingManager(payable(address(fmProxy)));
+
+        orderBook = makeAddr("orderBook");
+        eventMgr = makeAddr("eventMgr");
+
+        vm.prank(owner);
+        fm.setOrderBookManager(orderBook);
+        vm.prank(owner);
+        fm.setEventManager(eventMgr);
+    }
+
+    function testInitialize_AllContracts_UUPSUpgradeableInit() public {
+        // FundingManager
+        FundingManager fmImpl = new FundingManager();
+        bytes memory fmInitData = abi.encodeWithSignature("initialize(address)", owner);
+        FundingManagerProxy fmProxy = new FundingManagerProxy(address(fmImpl), fmInitData);
+        FundingManager fm = FundingManager(payable(address(fmProxy)));
+        assertEq(fm.owner(), owner);
+
+        // EventManager
+        EventManager emImpl = new EventManager();
+        bytes memory emInitData = abi.encodeWithSignature("initialize(address,address)", owner, address(0));
+        EventManagerProxy emProxy = new EventManagerProxy(address(emImpl), emInitData);
+        EventManager em = EventManager(address(emProxy));
+        assertEq(em.owner(), owner);
+
+        // OrderBookManager
+        OrderBookManager obmImpl = new OrderBookManager();
+        bytes memory obmInitData = abi.encodeWithSignature("initialize(address)", owner);
+        OrderBookManagerProxy obmProxy = new OrderBookManagerProxy(address(obmImpl), obmInitData);
+        OrderBookManager obm = OrderBookManager(address(obmProxy));
+        assertEq(obm.owner(), owner);
+
+        // FeeVaultManager
+        FeeVaultManager fvmImpl = new FeeVaultManager();
+        bytes memory fvmInitData = abi.encodeWithSignature("initialize(address)", owner);
+        FeeVaultManagerProxy fvmProxy = new FeeVaultManagerProxy(address(fvmImpl), fvmInitData);
+        FeeVaultManager fvm = FeeVaultManager(payable(address(fvmProxy)));
+        assertEq(fvm.owner(), owner);
+
+        // Verify upgrades are permitted for the owner
+        FundingManager newFmImpl = new FundingManager();
+        vm.prank(owner);
+        fm.upgradeToAndCall(address(newFmImpl), "");
+
+        EventManager newEmImpl = new EventManager();
+        vm.prank(owner);
+        em.upgradeToAndCall(address(newEmImpl), "");
+
+        OrderBookManager newObmImpl = new OrderBookManager();
+        vm.prank(owner);
+        obm.upgradeToAndCall(address(newObmImpl), "");
+
+        FeeVaultManager newFvmImpl = new FeeVaultManager();
+        vm.prank(owner);
+        fvm.upgradeToAndCall(address(newFvmImpl), "");
+    }
+
+    function testReceive_RevertsOnDirectETHTransfer() public {
+        FundingManager fmImpl = new FundingManager();
+        bytes memory fmInitData = abi.encodeWithSignature("initialize(address)", owner);
+        FundingManagerProxy fmProxy = new FundingManagerProxy(address(fmImpl), fmInitData);
+        FundingManager fm = FundingManager(payable(address(fmProxy)));
+
+        vm.deal(address(this), 1 ether);
+        (bool success, bytes memory returndata) = address(fm).call{value: 1 ether}("");
+        assertFalse(success);
+        assertEq(
+            returndata,
+            abi.encodeWithSignature("Error(string)", "FundingManager: direct ETH transfers not supported")
+        );
+    }
+
+    function testDeposit_ETHAmountMismatch_RevertsEarly() public {
+        address user = makeAddr("user");
+        FundingManagerHarness fmImpl = new FundingManagerHarness();
+        bytes memory fmInitData = abi.encodeWithSignature("initialize(address)", owner);
+        FundingManagerProxy fmProxy = new FundingManagerProxy(address(fmImpl), fmInitData);
+        FundingManagerHarness fm = FundingManagerHarness(payable(address(fmProxy)));
+
+        address nativeToken = fm.NATIVE_TOKEN();
+        vm.prank(owner);
+        fm.configureToken(nativeToken, 18, true);
+
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        vm.expectRevert("FundingManager: ETH amount mismatch");
+        fm.exposedDeposit(user, nativeToken, 0.5 ether, 0.25 ether);
+    }
+
+    function testMarkEventSettled_CalledByOrderBookManager_Succeeds() public {
+        (FundingManager fm, address orderBook, ) = _deployFundingManagerWithManagers();
+        uint256 eventId = 1;
+
+        vm.prank(orderBook);
+        fm.registerEvent(eventId, 2);
+
+        vm.prank(orderBook);
+        fm.markEventSettled(eventId, 0);
+
+        assertTrue(fm.isEventSettled(eventId));
+    }
+
+    function testMarkEventSettled_InvalidOutcome_Reverts() public {
+        (FundingManager fm, address orderBook, ) = _deployFundingManagerWithManagers();
+        uint256 eventId = 1;
+
+        vm.prank(orderBook);
+        fm.registerEvent(eventId, 2);
+
+        vm.prank(orderBook);
+        vm.expectRevert("FundingManager: invalid winning outcome");
+        fm.markEventSettled(eventId, 5);
+    }
+
+    function testMarkEventSettled_UnregisteredEvent_Reverts() public {
+        (FundingManager fm, address orderBook, ) = _deployFundingManagerWithManagers();
+
+        vm.prank(orderBook);
+        vm.expectRevert("FundingManager: event not registered");
+        fm.markEventSettled(999, 0);
+    }
+
+    function testMarkEventSettled_ValidOutcome_SetsWinner() public {
+        (FundingManager fm, address orderBook, ) = _deployFundingManagerWithManagers();
+        uint256 eventId = 1;
+
+        vm.prank(orderBook);
+        fm.registerEvent(eventId, 3);
+
+        vm.prank(orderBook);
+        fm.markEventSettled(eventId, 2);
+
+        assertTrue(fm.isEventSettled(eventId));
+        assertEq(fm.eventWinningOutcome(eventId), 2);
+    }
+
+    function testMarkEventSettled_CalledByEventManager_Reverts() public {
+        (FundingManager fm, address orderBook, address eventMgr) = _deployFundingManagerWithManagers();
+        uint256 eventId = 1;
+
+        vm.prank(orderBook);
+        fm.registerEvent(eventId, 2);
+
+        vm.prank(eventMgr);
+        vm.expectRevert("FundingManager: only orderBookManager");
+        fm.markEventSettled(eventId, 0);
+    }
+
+    function testGetTokenPrice_WithMockOracle_Returns1e18() public {
+        (FundingManager fm, , ) = _deployFundingManagerWithManagers();
+        address usdcToken = makeAddr("usdc");
+
+        vm.prank(owner);
+        fm.configureToken(usdcToken, 6, true);
+
+        MockOracleAdapter mockOracleAdapter = new MockOracleAdapter();
+        vm.prank(owner);
+        fm.setPriceOracleAdapter(address(mockOracleAdapter));
+
+        uint256 price = fm.getTokenPrice(usdcToken);
+        assertEq(price, 1e18);
+    }
+
+    function testGetTokenPrice_WithoutOracle_Returns1e18() public {
+        (FundingManager fm, , ) = _deployFundingManagerWithManagers();
+        address usdcToken = makeAddr("usdc");
+
+        vm.prank(owner);
+        fm.configureToken(usdcToken, 6, true);
+
+        uint256 price = fm.getTokenPrice(usdcToken);
+        assertEq(price, 1e18);
+    }
+
+    function testNormalizeToUsd_WithPriceOracle_SameAsWithout() public {
+        (FundingManager fm, , ) = _deployFundingManagerWithManagers();
+        address usdcToken = makeAddr("usdc");
+        uint256 amount = 100e6;
+
+        vm.prank(owner);
+        fm.configureToken(usdcToken, 6, true);
+
+        uint256 withoutOracle = fm.normalizeToUsd(usdcToken, amount);
+
+        MockOracleAdapter mockOracleAdapter = new MockOracleAdapter();
+        vm.prank(owner);
+        fm.setPriceOracleAdapter(address(mockOracleAdapter));
+
+        uint256 withOracle = fm.normalizeToUsd(usdcToken, amount);
+
+        assertEq(withoutOracle, withOracle);
+        assertEq(withOracle, 100e18);
+    }
+}

--- a/test/unit/FundingManagerETHWithdrawal.t.sol
+++ b/test/unit/FundingManagerETHWithdrawal.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {StdStorage, stdStorage} from "forge-std/StdStorage.sol";
+
+import {FundingManager} from "../../src/core/FundingManager.sol";
+import {FundingManagerProxy} from "../../src/core/proxies/FundingManagerProxy.sol";
+import {IFundingManager} from "../../src/interfaces/core/IFundingManager.sol";
+import {Errors} from "@openzeppelin/contracts/utils/Errors.sol";
+
+contract FundingManagerHarness is FundingManager {
+    function exposed_withdraw(address user, address tokenAddress, address payable withdrawAddress, uint256 usdAmount)
+        external
+    {
+        _withdraw(user, tokenAddress, withdrawAddress, usdAmount);
+    }
+}
+
+contract ReceiveOk {
+    receive() external payable {}
+}
+
+contract NoReceive {
+    // Intentionally no receive or fallback.
+}
+
+contract FundingManagerETHWithdrawalTest is Test {
+    using stdStorage for StdStorage;
+
+    FundingManagerHarness internal fundingManager;
+    address internal owner;
+    address internal feeVault;
+    address internal user;
+
+    ReceiveOk internal receiver;
+    NoReceive internal noReceive;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        feeVault = makeAddr("feeVault");
+        user = makeAddr("user");
+
+        FundingManagerHarness impl = new FundingManagerHarness();
+        bytes memory initData = abi.encodeWithSignature("initialize(address)", owner);
+        FundingManagerProxy proxy = new FundingManagerProxy(address(impl), initData);
+        fundingManager = FundingManagerHarness(payable(address(proxy)));
+
+        vm.startPrank(owner);
+        fundingManager.setFeeVaultManager(feeVault);
+        fundingManager.configureToken(fundingManager.NATIVE_TOKEN(), 18, true);
+        vm.stopPrank();
+
+        receiver = new ReceiveOk();
+        noReceive = new NoReceive();
+
+        vm.deal(address(fundingManager), 100 ether);
+    }
+
+    function testWithdrawETH_Success() public {
+        uint256 usdAmount = 2 ether;
+        address nativeToken = fundingManager.NATIVE_TOKEN();
+
+        _setUserUsdBalance(user, usdAmount);
+        _setTokenLiquidity(nativeToken, usdAmount);
+
+        uint256 beforeBalance = user.balance;
+        fundingManager.exposed_withdraw(user, nativeToken, payable(user), usdAmount);
+
+        assertEq(user.balance, beforeBalance + usdAmount);
+        assertEq(fundingManager.userUsdBalances(user), 0);
+        assertEq(fundingManager.tokenLiquidity(nativeToken), 0);
+    }
+
+    function testWithdrawETH_ToContractRecipient() public {
+        uint256 usdAmount = 1 ether;
+        address nativeToken = fundingManager.NATIVE_TOKEN();
+
+        _setUserUsdBalance(user, usdAmount);
+        _setTokenLiquidity(nativeToken, usdAmount);
+
+        uint256 beforeBalance = address(receiver).balance;
+        fundingManager.exposed_withdraw(user, nativeToken, payable(address(receiver)), usdAmount);
+
+        assertEq(address(receiver).balance, beforeBalance + usdAmount);
+    }
+
+    function testWithdrawETH_ToContractWithoutReceive_Reverts() public {
+        uint256 usdAmount = 1 ether;
+        address nativeToken = fundingManager.NATIVE_TOKEN();
+
+        _setUserUsdBalance(user, usdAmount);
+        _setTokenLiquidity(nativeToken, usdAmount);
+
+        vm.expectRevert(Errors.FailedCall.selector);
+        fundingManager.exposed_withdraw(user, nativeToken, payable(address(noReceive)), usdAmount);
+    }
+
+    function testWithdrawETH_RevertsOnInsufficientBalance() public {
+        uint256 usdAmount = 2 ether;
+        address nativeToken = fundingManager.NATIVE_TOKEN();
+
+        _setUserUsdBalance(user, 1 ether);
+        _setTokenLiquidity(nativeToken, usdAmount);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IFundingManager.InsufficientUsdBalance.selector, user, usdAmount, 1 ether)
+        );
+        fundingManager.exposed_withdraw(user, nativeToken, payable(user), usdAmount);
+    }
+
+    function testWithdrawLiquidity_ETH_Success() public {
+        uint256 amount = 3 ether;
+        address nativeToken = fundingManager.NATIVE_TOKEN();
+
+        _setTokenLiquidity(nativeToken, amount);
+        uint256 beforeBalance = user.balance;
+
+        vm.prank(feeVault);
+        fundingManager.withdrawLiquidity(nativeToken, amount, user);
+
+        assertEq(user.balance, beforeBalance + amount);
+        assertEq(fundingManager.tokenLiquidity(nativeToken), 0);
+    }
+
+    function testWithdrawLiquidity_ETH_ToContractWithoutReceive_Reverts() public {
+        uint256 amount = 1 ether;
+        address nativeToken = fundingManager.NATIVE_TOKEN();
+
+        _setTokenLiquidity(nativeToken, amount);
+
+        vm.prank(feeVault);
+        vm.expectRevert(Errors.FailedCall.selector);
+        fundingManager.withdrawLiquidity(nativeToken, amount, address(noReceive));
+    }
+
+    function _setUserUsdBalance(address account, uint256 usdAmount) internal {
+        stdstore
+            .target(address(fundingManager))
+            .sig("userUsdBalances(address)")
+            .with_key(account)
+            .checked_write(usdAmount);
+    }
+
+    function _setTokenLiquidity(address token, uint256 amount) internal {
+        stdstore
+            .target(address(fundingManager))
+            .sig("tokenLiquidity(address)")
+            .with_key(token)
+            .checked_write(amount);
+    }
+}

--- a/test/unit/FundingManagerPrecision.t.sol
+++ b/test/unit/FundingManagerPrecision.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {StdStorage, stdStorage} from "forge-std/StdStorage.sol";
+
+import {FundingManager} from "../../src/core/FundingManager.sol";
+import {FundingManagerProxy} from "../../src/core/proxies/FundingManagerProxy.sol";
+import {FixedPointMathLib} from "@solady/utils/FixedPointMathLib.sol";
+
+contract FundingManagerPrecisionTest is Test {
+    using stdStorage for StdStorage;
+
+    FundingManager internal fundingManager;
+    address internal owner;
+    address internal orderBook;
+    address internal buyer;
+    address internal seller;
+
+    uint256 internal constant EVENT_ID = 1;
+    uint8 internal constant OUTCOME_INDEX = 0;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        orderBook = makeAddr("orderBook");
+        buyer = makeAddr("buyer");
+        seller = makeAddr("seller");
+
+        FundingManager impl = new FundingManager();
+        bytes memory initData = abi.encodeWithSignature("initialize(address)", owner);
+        FundingManagerProxy proxy = new FundingManagerProxy(address(impl), initData);
+        fundingManager = FundingManager(payable(address(proxy)));
+
+        vm.startPrank(owner);
+        fundingManager.setOrderBookManager(orderBook);
+        vm.stopPrank();
+    }
+
+    function testSettleMatchedOrder_NormalAmount() public {
+        uint256 buyOrderId = 1;
+        uint256 sellOrderId = 2;
+        uint256 matchAmount = 100 ether;
+        uint256 matchPrice = 5000;
+        uint256 payment = 50 ether;
+
+        _setOrderLockedUsd(buyOrderId, payment);
+        _setOrderLockedLong(sellOrderId, matchAmount);
+
+        vm.prank(orderBook);
+        fundingManager.settleMatchedOrder(
+            buyOrderId,
+            sellOrderId,
+            buyer,
+            seller,
+            matchAmount,
+            matchPrice,
+            EVENT_ID,
+            OUTCOME_INDEX
+        );
+
+        assertEq(fundingManager.orderLockedUsd(buyOrderId), 0);
+        assertEq(fundingManager.orderLockedLong(sellOrderId), 0);
+        assertEq(fundingManager.getLongPosition(buyer, EVENT_ID, OUTCOME_INDEX), matchAmount);
+        assertEq(fundingManager.getUserUsdBalance(seller), payment);
+    }
+
+    function testSettleMatchedOrder_SmallAmount_NonZeroPayment() public {
+        uint256 buyOrderId = 3;
+        uint256 sellOrderId = 4;
+        uint256 matchAmount = 1e14;
+        uint256 matchPrice = 100;
+        uint256 payment = 1e12;
+
+        _setOrderLockedUsd(buyOrderId, payment);
+        _setOrderLockedLong(sellOrderId, matchAmount);
+
+        vm.prank(orderBook);
+        fundingManager.settleMatchedOrder(
+            buyOrderId,
+            sellOrderId,
+            buyer,
+            seller,
+            matchAmount,
+            matchPrice,
+            EVENT_ID,
+            OUTCOME_INDEX
+        );
+
+        assertEq(fundingManager.getUserUsdBalance(seller), payment);
+    }
+
+    function testSettleMatchedOrder_VerySmallAmount_RevertsOnZeroPayment() public {
+        uint256 buyOrderId = 5;
+        uint256 sellOrderId = 6;
+        uint256 matchAmount = 1;
+        uint256 matchPrice = 1;
+
+        _setOrderLockedUsd(buyOrderId, 0);
+        _setOrderLockedLong(sellOrderId, matchAmount);
+
+        vm.prank(orderBook);
+        vm.expectRevert("FundingManager: payment rounds to zero");
+        fundingManager.settleMatchedOrder(
+            buyOrderId,
+            sellOrderId,
+            buyer,
+            seller,
+            matchAmount,
+            matchPrice,
+            EVENT_ID,
+            OUTCOME_INDEX
+        );
+    }
+
+    function testSettleMatchedOrder_ZeroAmount_Allowed() public {
+        uint256 buyOrderId = 7;
+        uint256 sellOrderId = 8;
+        uint256 matchAmount = 0;
+        uint256 matchPrice = 1;
+
+        _setOrderLockedUsd(buyOrderId, 0);
+        _setOrderLockedLong(sellOrderId, 0);
+
+        vm.prank(orderBook);
+        fundingManager.settleMatchedOrder(
+            buyOrderId,
+            sellOrderId,
+            buyer,
+            seller,
+            matchAmount,
+            matchPrice,
+            EVENT_ID,
+            OUTCOME_INDEX
+        );
+
+        assertEq(fundingManager.getUserUsdBalance(seller), 0);
+    }
+
+    function testFuzz_SettleMatchedOrder_PaymentNeverExceedsAmount(uint256 matchAmount, uint256 matchPrice) public {
+        uint256 pricePrecision = fundingManager.PRICE_PRECISION();
+        matchPrice = bound(matchPrice, 1, pricePrecision);
+        matchAmount = bound(matchAmount, 1, type(uint256).max / pricePrecision);
+
+        uint256 payment = FixedPointMathLib.mulDiv(matchAmount, matchPrice, pricePrecision);
+        vm.assume(payment > 0);
+
+        uint256 buyOrderId = 9;
+        uint256 sellOrderId = 10;
+
+        _setOrderLockedUsd(buyOrderId, payment);
+        _setOrderLockedLong(sellOrderId, matchAmount);
+
+        vm.prank(orderBook);
+        fundingManager.settleMatchedOrder(
+            buyOrderId,
+            sellOrderId,
+            buyer,
+            seller,
+            matchAmount,
+            matchPrice,
+            EVENT_ID,
+            OUTCOME_INDEX
+        );
+
+        assertLe(payment, matchAmount);
+        assertEq(fundingManager.getUserUsdBalance(seller), payment);
+    }
+
+    function testSettleMatchedOrder_LargeValues_NoOverflow() public {
+        uint256 buyOrderId = 11;
+        uint256 sellOrderId = 12;
+        uint256 matchAmount = type(uint256).max / fundingManager.PRICE_PRECISION();
+        uint256 matchPrice = fundingManager.PRICE_PRECISION();
+
+        uint256 payment = FixedPointMathLib.mulDiv(matchAmount, matchPrice, fundingManager.PRICE_PRECISION());
+
+        _setOrderLockedUsd(buyOrderId, payment);
+        _setOrderLockedLong(sellOrderId, matchAmount);
+
+        vm.prank(orderBook);
+        fundingManager.settleMatchedOrder(
+            buyOrderId,
+            sellOrderId,
+            buyer,
+            seller,
+            matchAmount,
+            matchPrice,
+            EVENT_ID,
+            OUTCOME_INDEX
+        );
+
+        assertEq(fundingManager.getUserUsdBalance(seller), payment);
+    }
+
+    function _setOrderLockedUsd(uint256 orderId, uint256 amount) internal {
+        stdstore
+            .target(address(fundingManager))
+            .sig("orderLockedUsd(uint256)")
+            .with_key(orderId)
+            .checked_write(amount);
+    }
+
+    function _setOrderLockedLong(uint256 orderId, uint256 amount) internal {
+        stdstore
+            .target(address(fundingManager))
+            .sig("orderLockedLong(uint256)")
+            .with_key(orderId)
+            .checked_write(amount);
+    }
+}

--- a/test/unit/FundingManagerPriceOracle.t.sol
+++ b/test/unit/FundingManagerPriceOracle.t.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {FundingManager} from "../../src/core/FundingManager.sol";
+import {FundingManagerProxy} from "../../src/core/proxies/FundingManagerProxy.sol";
+import {MockOracleAdapter} from "../../src/oracle/mock/MockOracleAdapter.sol";
+import {IFundingManager} from "../../src/interfaces/core/IFundingManager.sol";
+import {IPriceOracle} from "../../src/interfaces/oracle/IPriceOracle.sol";
+import {FixedPointMathLib} from "@solady/utils/FixedPointMathLib.sol";
+
+contract ConfigurablePriceOracle is IPriceOracle {
+    mapping(address => uint256) public prices;
+
+    function setPrice(address token, uint256 price) external {
+        prices[token] = price;
+    }
+
+    function getTokenPrice(address token) external view returns (uint256 price) {
+        price = prices[token];
+        require(price != 0, "PriceOracle: price not set");
+    }
+}
+
+contract RevertingPriceOracle is IPriceOracle {
+    function getTokenPrice(address) external pure returns (uint256) {
+        revert("PriceOracle: revert");
+    }
+}
+
+contract FundingManagerPriceOracleTest is Test {
+    event PriceOracleAdapterUpdated(address indexed newAdapter);
+
+    FundingManager internal fundingManager;
+    address internal owner;
+    address internal token6;
+    address internal token8;
+    address internal token18;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+
+        FundingManager impl = new FundingManager();
+        bytes memory initData = abi.encodeWithSignature("initialize(address)", owner);
+        FundingManagerProxy proxy = new FundingManagerProxy(address(impl), initData);
+        fundingManager = FundingManager(payable(address(proxy)));
+
+        token6 = makeAddr("token6");
+        token8 = makeAddr("token8");
+        token18 = makeAddr("token18");
+
+        vm.startPrank(owner);
+        fundingManager.configureToken(token6, 6, true);
+        fundingManager.configureToken(token8, 8, true);
+        fundingManager.configureToken(token18, 18, true);
+        vm.stopPrank();
+    }
+
+    function testSetPriceOracleAdapter_OwnerCanSet_EmitsEvent() public {
+        ConfigurablePriceOracle oracle = new ConfigurablePriceOracle();
+
+        vm.prank(owner);
+        vm.expectEmit(true, false, false, true);
+        emit PriceOracleAdapterUpdated(address(oracle));
+        fundingManager.setPriceOracleAdapter(address(oracle));
+
+        assertEq(address(fundingManager.priceOracleAdapter()), address(oracle));
+    }
+
+    function testSetPriceOracleAdapter_NonOwnerReverts() public {
+        ConfigurablePriceOracle oracle = new ConfigurablePriceOracle();
+
+        vm.prank(makeAddr("notOwner"));
+        vm.expectRevert();
+        fundingManager.setPriceOracleAdapter(address(oracle));
+    }
+
+    function testSetPriceOracleAdapter_ZeroAddressReverts() public {
+        vm.prank(owner);
+        vm.expectRevert("FundingManager: invalid address");
+        fundingManager.setPriceOracleAdapter(address(0));
+    }
+
+    function testSetPriceOracleAdapter_CanUpdate() public {
+        ConfigurablePriceOracle oracleA = new ConfigurablePriceOracle();
+        ConfigurablePriceOracle oracleB = new ConfigurablePriceOracle();
+
+        vm.startPrank(owner);
+        fundingManager.setPriceOracleAdapter(address(oracleA));
+        fundingManager.setPriceOracleAdapter(address(oracleB));
+        vm.stopPrank();
+
+        assertEq(address(fundingManager.priceOracleAdapter()), address(oracleB));
+    }
+
+    function testGetTokenPrice_WithoutOracle_Returns1e18() public {
+        uint256 price = fundingManager.getTokenPrice(token6);
+        assertEq(price, 1e18);
+    }
+
+    function testGetTokenPrice_WithMockOracle_Returns1e18() public {
+        MockOracleAdapter mockOracleAdapter = new MockOracleAdapter();
+
+        vm.prank(owner);
+        fundingManager.setPriceOracleAdapter(address(mockOracleAdapter));
+
+        uint256 price = fundingManager.getTokenPrice(token6);
+        assertEq(price, 1e18);
+    }
+
+    function testGetTokenPrice_WithConfigurableOracle_ReturnsConfiguredPrice() public {
+        ConfigurablePriceOracle oracle = new ConfigurablePriceOracle();
+        oracle.setPrice(token18, 2000e18);
+
+        vm.prank(owner);
+        fundingManager.setPriceOracleAdapter(address(oracle));
+
+        uint256 price = fundingManager.getTokenPrice(token18);
+        assertEq(price, 2000e18);
+    }
+
+    function testGetTokenPrice_UnsupportedToken_Reverts() public {
+        address unsupported = makeAddr("unsupported");
+
+        vm.expectRevert(abi.encodeWithSelector(IFundingManager.TokenIsNotSupported.selector, unsupported));
+        fundingManager.getTokenPrice(unsupported);
+    }
+
+    function testGetTokenPrice_RevertingOracle_PropagatesRevert() public {
+        RevertingPriceOracle oracle = new RevertingPriceOracle();
+
+        vm.prank(owner);
+        fundingManager.setPriceOracleAdapter(address(oracle));
+
+        vm.expectRevert("PriceOracle: revert");
+        fundingManager.getTokenPrice(token6);
+    }
+
+    function testNormalizeToUsd_WithoutOracle_StablecoinBehavior() public {
+        uint256 amount = 100e6;
+        uint256 usdAmount = fundingManager.normalizeToUsd(token6, amount);
+        assertEq(usdAmount, 100e18);
+    }
+
+    function testNormalizeToUsd_WithMockOracle_SameAsWithoutOracle() public {
+        uint256 amount = 100e6;
+        uint256 withoutOracle = fundingManager.normalizeToUsd(token6, amount);
+
+        MockOracleAdapter mockOracleAdapter = new MockOracleAdapter();
+        vm.prank(owner);
+        fundingManager.setPriceOracleAdapter(address(mockOracleAdapter));
+
+        uint256 withOracle = fundingManager.normalizeToUsd(token6, amount);
+        assertEq(withOracle, withoutOracle);
+    }
+
+    function testNormalizeToUsd_WithConfigurableOracle_AppliesPrice() public {
+        ConfigurablePriceOracle oracle = new ConfigurablePriceOracle();
+        oracle.setPrice(token18, 2e18);
+
+        vm.prank(owner);
+        fundingManager.setPriceOracleAdapter(address(oracle));
+
+        uint256 amount = 100e18;
+        uint256 usdAmount = fundingManager.normalizeToUsd(token18, amount);
+        assertEq(usdAmount, 200e18);
+    }
+
+    function testNormalizeToUsd_DifferentDecimals_Correct() public {
+        ConfigurablePriceOracle oracle = new ConfigurablePriceOracle();
+        oracle.setPrice(token8, 10e18);
+
+        vm.prank(owner);
+        fundingManager.setPriceOracleAdapter(address(oracle));
+
+        uint256 amount = 5e8;
+        uint256 usdAmount = fundingManager.normalizeToUsd(token8, amount);
+        assertEq(usdAmount, 50e18);
+    }
+
+    function testDenormalizeFromUsd_WithoutOracle_StablecoinBehavior() public {
+        uint256 usdAmount = 100e18;
+        uint256 tokenAmount = fundingManager.denormalizeFromUsd(token6, usdAmount);
+        assertEq(tokenAmount, 100e6);
+    }
+
+    function testDenormalizeFromUsd_WithMockOracle_SameAsWithoutOracle() public {
+        uint256 usdAmount = 100e18;
+        uint256 withoutOracle = fundingManager.denormalizeFromUsd(token6, usdAmount);
+
+        MockOracleAdapter mockOracleAdapter = new MockOracleAdapter();
+        vm.prank(owner);
+        fundingManager.setPriceOracleAdapter(address(mockOracleAdapter));
+
+        uint256 withOracle = fundingManager.denormalizeFromUsd(token6, usdAmount);
+        assertEq(withOracle, withoutOracle);
+    }
+
+    function testDenormalizeFromUsd_WithConfigurableOracle_AppliesPrice() public {
+        ConfigurablePriceOracle oracle = new ConfigurablePriceOracle();
+        oracle.setPrice(token18, 2e18);
+
+        vm.prank(owner);
+        fundingManager.setPriceOracleAdapter(address(oracle));
+
+        uint256 usdAmount = 200e18;
+        uint256 tokenAmount = fundingManager.denormalizeFromUsd(token18, usdAmount);
+        assertEq(tokenAmount, 100e18);
+    }
+
+    function testDenormalizeFromUsd_RoundTrip_PriceTwoX() public {
+        ConfigurablePriceOracle oracle = new ConfigurablePriceOracle();
+        oracle.setPrice(token6, 2e18);
+
+        vm.prank(owner);
+        fundingManager.setPriceOracleAdapter(address(oracle));
+
+        uint256 amount = 123e6;
+        uint256 usdAmount = fundingManager.normalizeToUsd(token6, amount);
+        uint256 roundTrip = fundingManager.denormalizeFromUsd(token6, usdAmount);
+
+        assertEq(roundTrip, amount);
+    }
+
+    function testMulDiv_OneToOneIdentity() public {
+        uint256 value = 987654321;
+        uint256 result = FixedPointMathLib.mulDiv(value, 1e18, 1e18);
+        assertEq(result, value);
+    }
+}

--- a/test/unit/FundingManagerTokenConfig.t.sol
+++ b/test/unit/FundingManagerTokenConfig.t.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {FundingManager} from "../../src/core/FundingManager.sol";
+import {FundingManagerProxy} from "../../src/core/proxies/FundingManagerProxy.sol";
+
+contract FundingManagerTokenConfigTest is Test {
+    FundingManager internal fundingManager;
+    address internal owner;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+
+        FundingManager impl = new FundingManager();
+        bytes memory initData = abi.encodeWithSignature("initialize(address)", owner);
+        FundingManagerProxy proxy = new FundingManagerProxy(address(impl), initData);
+        fundingManager = FundingManager(payable(address(proxy)));
+    }
+
+    function testConfigureToken_NewToken_AddsToList() public {
+        address token = _tokenAddress(1);
+
+        vm.prank(owner);
+        fundingManager.configureToken(token, 18, true);
+
+        address[] memory tokens = fundingManager.getSupportedTokens();
+        assertEq(tokens.length, 1);
+        assertEq(tokens[0], token);
+    }
+
+    function testConfigureToken_SameTokenTwice_NoDuplicate() public {
+        address token = _tokenAddress(2);
+
+        vm.prank(owner);
+        fundingManager.configureToken(token, 18, true);
+        vm.prank(owner);
+        fundingManager.configureToken(token, 18, true);
+
+        address[] memory tokens = fundingManager.getSupportedTokens();
+        assertEq(tokens.length, 1);
+        assertEq(tokens[0], token);
+    }
+
+    function testConfigureToken_DisableThenReEnable_NoDuplicate() public {
+        address token = _tokenAddress(3);
+
+        vm.prank(owner);
+        fundingManager.configureToken(token, 18, true);
+        vm.prank(owner);
+        fundingManager.configureToken(token, 18, false);
+        vm.prank(owner);
+        fundingManager.configureToken(token, 18, true);
+
+        address[] memory tokens = fundingManager.getSupportedTokens();
+        assertEq(tokens.length, 1);
+        assertEq(tokens[0], token);
+    }
+
+    function testConfigureToken_ManyTokens_GasEfficient() public {
+        for (uint256 i = 1; i <= 60; i++) {
+            vm.prank(owner);
+            fundingManager.configureToken(_tokenAddress(i), 18, true);
+        }
+
+        address[] memory tokens = fundingManager.getSupportedTokens();
+        assertEq(tokens.length, 60);
+    }
+
+    function testConfigureToken_DisabledToken_NotAddedToList() public {
+        address token = _tokenAddress(99);
+
+        vm.prank(owner);
+        fundingManager.configureToken(token, 18, false);
+
+        address[] memory tokens = fundingManager.getSupportedTokens();
+        assertEq(tokens.length, 0);
+    }
+
+    function testFuzz_ConfigureToken_NeverDuplicates(address tokenA, address tokenB, bool enableA, bool enableB) public {
+        vm.assume(tokenA != address(0));
+        vm.assume(tokenB != address(0));
+
+        vm.prank(owner);
+        fundingManager.configureToken(tokenA, 18, enableA);
+        vm.prank(owner);
+        fundingManager.configureToken(tokenB, 18, enableB);
+        vm.prank(owner);
+        fundingManager.configureToken(tokenA, 18, enableA);
+
+        address[] memory tokens = fundingManager.getSupportedTokens();
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            for (uint256 j = i + 1; j < tokens.length; j++) {
+                assertTrue(tokens[i] != tokens[j]);
+            }
+        }
+
+        uint256 expected = 0;
+        if (enableA) {
+            expected = 1;
+        }
+        if (enableB) {
+            if (tokenB != tokenA) {
+                expected += 1;
+            } else if (expected == 0) {
+                expected = 1;
+            }
+        }
+        assertEq(tokens.length, expected);
+    }
+
+    function _tokenAddress(uint256 salt) internal pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(salt)))));
+    }
+}


### PR DESCRIPTION
… M4, C1)

Implement 6 security fixes identified in security audit:

H1 (UUPS Init): Resolved - __UUPSUpgradeable_init() doesn't exist in OZ v5.x
- No action needed, OpenZeppelin v5.x handles UUPS initialization automatically

C2 (Receive Revert): Add revert to receive() function
- Prevent accidental ETH loss by reverting direct transfers
- Add TODO comment for future ETH deposit routing
- FundingManager.sol: receive() now reverts with clear error message

M3 (ETH Validation): Move ETH validation to beginning of deposit flow
- Fail-fast behavior for invalid ETH deposits
- Save gas on invalid calls by checking before expensive operations
- FundingManager.sol: ETH amount validation moved before USD normalization

M2 (Access Control): Fix markEventSettled access control
- Change modifier from onlyEventManager to onlyOrderBookManager
- Fixes critical bug that would prevent event settlement
- FundingManager.sol: markEventSettled() now uses correct access control

M4 (Outcome Validation): Add winningOutcomeIndex validation
- Validate winning outcome index is within valid range
- Prevent invalid outcomes from locking prize pools
- FundingManager.sol: Added bounds check for winningOutcomeIndex

C1 (Oracle Integration): Implement price oracle adapter pattern
- Add IPriceOracle interface for adapter pattern
- MockOracleAdapter implements dual role (IOracle + IPriceOracle)
- FundingManager uses typed interface reference for price queries
- Graceful fallback to 1:1 USD when oracle not configured
- Update normalize/denormalize functions to apply token prices
- Comprehensive test coverage (18 tests + 3 integration tests)

Files modified:
- src/core/FundingManager.sol (all fixes)
- src/interfaces/core/IFundingManager.sol (C1)
- src/interfaces/oracle/IPriceOracle.sol (new, C1)
- src/oracle/mock/MockOracleAdapter.sol (C1)
- src/interfaces/oracle/IMockOracleAdapter.sol (C1)
- script/deploy/local/V1/ContractsLinker.s.sol (C1)
- test/unit/*.t.sol (comprehensive test suite)

All tests pass. Backward compatible. No behavioral changes for stablecoin-only use case.